### PR TITLE
Handle double unregistration of listener

### DIFF
--- a/dmc_touchmanager.lua
+++ b/dmc_touchmanager.lua
@@ -170,9 +170,10 @@ end
 --
 function TouchManager:unregister( obj, handler )
 	local r = self:_getRegisteredObject( obj )
-
-	self:_setRegisteredObject( obj, nil )
-	obj:removeEventListener( "touch", r.callback )
+    if r then
+	    self:_setRegisteredObject( obj, nil )
+	    obj:removeEventListener( "touch", r.callback )
+    end
 end
 
 


### PR DESCRIPTION
Handle scenario, where touch listener is unregistered twice. This can happen if you unregister your listener as part of your logic and also want to unregister in cleanup function. This is implemented in order not to store any flags indicating that listener was already unregistered.
