### PR TITLE
typo in touch event phase, should be "cancelled"

### DIFF
--- a/dmc_multitouch.lua
+++ b/dmc_multitouch.lua
@@ -1239,7 +1239,7 @@ function multitouchTouchHandler( event )
 		end
 
 
-	elseif ( event.phase == 'ended' or event.phase == 'canceled' ) then
+	elseif ( event.phase == 'ended' or event.phase == 'cancelled' ) then
 
 		if event.isFocused then
 


### PR DESCRIPTION
this caused apps to be unresponsive when changing rotation on android
